### PR TITLE
Allow to override build date

### DIFF
--- a/src/DefaultSig.pm
+++ b/src/DefaultSig.pm
@@ -109,9 +109,10 @@ sub monthnames {my $self = shift;  return [qw(Jan Feb Mar May Jun Jul Aug Sep Oc
 sub update_date_and_time {
     my $self = shift;
 
+    my $now = $ENV{SOURCE_DATE_EPOCH} || time;
     my ($second, $minute, $hour,
         $day_of_month, $month, $year,
-        $day_of_week) = $self->is_using_gmt() ? gmtime : localtime;
+        $day_of_week) = $self->is_using_gmt() ? gmtime($now) : localtime($now);
 
     $self->{DATE} = $self->format_date($day_of_month, $month, $year + 1900, $day_of_week,
                                        $self->weekdays->[$day_of_week],


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.